### PR TITLE
Expand FFI interface

### DIFF
--- a/bindings/AkatsukiPPFFI.cs
+++ b/bindings/AkatsukiPPFFI.cs
@@ -20,7 +20,10 @@ namespace My.Company
 
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "calculate_score")]
-        public static extern CalculatePerformanceResult calculate_score(ref sbyte beatmap_path, uint mode, uint mods, uint max_combo, double accuracy, uint miss_count, Optionu32 passed_objects);
+        public static extern CalculatePerformanceResult calculate_score(ref sbyte beatmap_path, uint mode, uint mods, uint max_combo, Optionf64 accuracy, Optionu32 count_300, Optionu32 count_100, Optionu32 count_50, uint miss_count, Optionu32 passed_objects);
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "calculate_score_bytes")]
+        public static extern CalculatePerformanceResult calculate_score_bytes(Sliceu8 beatmap_bytes, uint mode, uint mods, uint max_combo, Optionf64 accuracy, Optionu32 count_300, Optionu32 count_100, Optionu32 count_50, uint miss_count, Optionu32 passed_objects);
 
     }
 
@@ -30,7 +33,101 @@ namespace My.Company
     {
         public double pp;
         public double stars;
+        public double ar;
+        public double od;
+        public uint max_combo;
     }
+
+    ///A pointer to an array of data someone else owns which may not be modified.
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
+    public partial struct Sliceu8
+    {
+        ///Pointer to start of immutable data.
+        IntPtr data;
+        ///Number of elements.
+        ulong len;
+    }
+
+    public partial struct Sliceu8 : IEnumerable<byte>
+    {
+        public Sliceu8(GCHandle handle, ulong count)
+        {
+            this.data = handle.AddrOfPinnedObject();
+            this.len = count;
+        }
+        public Sliceu8(IntPtr handle, ulong count)
+        {
+            this.data = handle;
+            this.len = count;
+        }
+        public byte this[int i]
+        {
+            get
+            {
+                if (i >= Count) throw new IndexOutOfRangeException();
+                var size = Marshal.SizeOf(typeof(byte));
+                var ptr = new IntPtr(data.ToInt64() + i * size);
+                return Marshal.PtrToStructure<byte>(ptr);
+            }
+        }
+        public byte[] Copied
+        {
+            get
+            {
+                var rval = new byte[len];
+                for (var i = 0; i < (int) len; i++) {
+                    rval[i] = this[i];
+                }
+                return rval;
+            }
+        }
+        public int Count => (int) len;
+        public IEnumerator<byte> GetEnumerator()
+        {
+            for (var i = 0; i < (int)len; ++i)
+            {
+                yield return this[i];
+            }
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+
+
+    ///Option type containing boolean flag and maybe valid data.
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
+    public partial struct Optionf64
+    {
+        ///Element that is maybe valid.
+        double t;
+        ///Byte where `1` means element `t` is valid.
+        byte is_some;
+    }
+
+    public partial struct Optionf64
+    {
+        public static Optionf64 FromNullable(double? nullable)
+        {
+            var result = new Optionf64();
+            if (nullable.HasValue)
+            {
+                result.is_some = 1;
+                result.t = nullable.Value;
+            }
+
+            return result;
+        }
+
+        public double? ToNullable()
+        {
+            return this.is_some == 1 ? this.t : (double?)null;
+        }
+    }
+
 
     ///Option type containing boolean flag and maybe valid data.
     [Serializable]

--- a/bindings/AkatsukiPPFFI.cs
+++ b/bindings/AkatsukiPPFFI.cs
@@ -19,11 +19,11 @@ namespace My.Company
         }
 
 
-        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "calculate_score")]
-        public static extern CalculatePerformanceResult calculate_score(ref sbyte beatmap_path, uint mode, uint mods, uint max_combo, Optionf64 accuracy, Optionu32 count_300, Optionu32 count_100, Optionu32 count_50, uint miss_count, Optionu32 passed_objects);
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "calculate_performance_from_path")]
+        public static extern CalculatePerformanceResult calculate_performance_from_path(ref sbyte beatmap_path, uint mode, uint mods, uint max_combo, Optionf64 accuracy, Optionu32 count_300, Optionu32 count_100, Optionu32 count_50, uint miss_count, Optionu32 passed_objects);
 
-        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "calculate_score_bytes")]
-        public static extern CalculatePerformanceResult calculate_score_bytes(Sliceu8 beatmap_bytes, uint mode, uint mods, uint max_combo, Optionf64 accuracy, Optionu32 count_300, Optionu32 count_100, Optionu32 count_50, uint miss_count, Optionu32 passed_objects);
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "calculate_performance_from_bytes")]
+        public static extern CalculatePerformanceResult calculate_performance_from_bytes(Sliceu8 beatmap_bytes, uint mode, uint mods, uint max_combo, Optionf64 accuracy, Optionu32 count_300, Optionu32 count_100, Optionu32 count_50, uint miss_count, Optionu32 passed_objects);
 
     }
 

--- a/bindings/akatsuki_pp_ffi.h
+++ b/bindings/akatsuki_pp_ffi.h
@@ -17,17 +17,42 @@ typedef struct calculateperformanceresult
     {
     double pp;
     double stars;
+    double ar;
+    double od;
+    uint32_t max_combo;
     } calculateperformanceresult;
+
+///Option type containing boolean flag and maybe valid data.
+typedef struct optionf64
+    {
+    ///Element that is maybe valid.
+    double t;
+    ///Byte where `1` means element `t` is valid.
+    uint8_t is_some;
+    } optionf64;
 
 ///Option type containing boolean flag and maybe valid data.
 typedef struct optionu32
     {
+    ///Element that is maybe valid.
     uint32_t t;
+    ///Byte where `1` means element `t` is valid.
     uint8_t is_some;
     } optionu32;
 
+///A pointer to an array of data someone else owns which may not be modified.
+typedef struct sliceu8
+    {
+    ///Pointer to start of immutable data.
+    const uint8_t* data;
+    ///Number of elements.
+    uint64_t len;
+    } sliceu8;
 
-calculateperformanceresult calculate_score(const int8_t* beatmap_path, uint32_t mode, uint32_t mods, uint32_t max_combo, double accuracy, uint32_t miss_count, optionu32 passed_objects);
+
+calculateperformanceresult calculate_score(const int8_t* beatmap_path, uint32_t mode, uint32_t mods, uint32_t max_combo, optionf64 accuracy, optionu32 count_300, optionu32 count_100, optionu32 count_50, uint32_t miss_count, optionu32 passed_objects);
+
+calculateperformanceresult calculate_score_bytes(sliceu8 beatmap_bytes, uint32_t mode, uint32_t mods, uint32_t max_combo, optionf64 accuracy, optionu32 count_300, optionu32 count_100, optionu32 count_50, uint32_t miss_count, optionu32 passed_objects);
 
 
 #ifdef __cplusplus

--- a/bindings/akatsuki_pp_ffi.h
+++ b/bindings/akatsuki_pp_ffi.h
@@ -50,9 +50,9 @@ typedef struct sliceu8
     } sliceu8;
 
 
-calculateperformanceresult calculate_score(const int8_t* beatmap_path, uint32_t mode, uint32_t mods, uint32_t max_combo, optionf64 accuracy, optionu32 count_300, optionu32 count_100, optionu32 count_50, uint32_t miss_count, optionu32 passed_objects);
+calculateperformanceresult calculate_performance_from_path(const int8_t* beatmap_path, uint32_t mode, uint32_t mods, uint32_t max_combo, optionf64 accuracy, optionu32 count_300, optionu32 count_100, optionu32 count_50, uint32_t miss_count, optionu32 passed_objects);
 
-calculateperformanceresult calculate_score_bytes(sliceu8 beatmap_bytes, uint32_t mode, uint32_t mods, uint32_t max_combo, optionf64 accuracy, optionu32 count_300, optionu32 count_100, optionu32 count_50, uint32_t miss_count, optionu32 passed_objects);
+calculateperformanceresult calculate_performance_from_bytes(sliceu8 beatmap_bytes, uint32_t mode, uint32_t mods, uint32_t max_combo, optionf64 accuracy, optionu32 count_300, optionu32 count_100, optionu32 count_50, uint32_t miss_count, optionu32 passed_objects);
 
 
 #ifdef __cplusplus

--- a/bindings/akatsuki_pp_ffi.py
+++ b/bindings/akatsuki_pp_ffi.py
@@ -10,22 +10,22 @@ def init_lib(path):
     global c_lib
     c_lib = ctypes.cdll.LoadLibrary(path)
 
-    c_lib.calculate_score.argtypes = [ctypes.POINTER(ctypes.c_int8), ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32, Optionf64, Optionu32, Optionu32, Optionu32, ctypes.c_uint32, Optionu32]
-    c_lib.calculate_score_bytes.argtypes = [Sliceu8, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32, Optionf64, Optionu32, Optionu32, Optionu32, ctypes.c_uint32, Optionu32]
+    c_lib.calculate_performance_from_path.argtypes = [ctypes.POINTER(ctypes.c_int8), ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32, Optionf64, Optionu32, Optionu32, Optionu32, ctypes.c_uint32, Optionu32]
+    c_lib.calculate_performance_from_bytes.argtypes = [Sliceu8, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32, Optionf64, Optionu32, Optionu32, Optionu32, ctypes.c_uint32, Optionu32]
 
-    c_lib.calculate_score.restype = CalculatePerformanceResult
-    c_lib.calculate_score_bytes.restype = CalculatePerformanceResult
+    c_lib.calculate_performance_from_path.restype = CalculatePerformanceResult
+    c_lib.calculate_performance_from_bytes.restype = CalculatePerformanceResult
 
 
 
-def calculate_score(beatmap_path: ctypes.POINTER(ctypes.c_int8), mode: int, mods: int, max_combo: int, accuracy: Optionf64, count_300: Optionu32, count_100: Optionu32, count_50: Optionu32, miss_count: int, passed_objects: Optionu32) -> CalculatePerformanceResult:
-    return c_lib.calculate_score(beatmap_path, mode, mods, max_combo, accuracy, count_300, count_100, count_50, miss_count, passed_objects)
+def calculate_performance_from_path(beatmap_path: ctypes.POINTER(ctypes.c_int8), mode: int, mods: int, max_combo: int, accuracy: Optionf64, count_300: Optionu32, count_100: Optionu32, count_50: Optionu32, miss_count: int, passed_objects: Optionu32) -> CalculatePerformanceResult:
+    return c_lib.calculate_performance_from_path(beatmap_path, mode, mods, max_combo, accuracy, count_300, count_100, count_50, miss_count, passed_objects)
 
-def calculate_score_bytes(beatmap_bytes: Sliceu8 | ctypes.Array[ctypes.c_uint8], mode: int, mods: int, max_combo: int, accuracy: Optionf64, count_300: Optionu32, count_100: Optionu32, count_50: Optionu32, miss_count: int, passed_objects: Optionu32) -> CalculatePerformanceResult:
+def calculate_performance_from_bytes(beatmap_bytes: Sliceu8 | ctypes.Array[ctypes.c_uint8], mode: int, mods: int, max_combo: int, accuracy: Optionf64, count_300: Optionu32, count_100: Optionu32, count_50: Optionu32, miss_count: int, passed_objects: Optionu32) -> CalculatePerformanceResult:
     if hasattr(beatmap_bytes, "_length_") and getattr(beatmap_bytes, "_type_", "") == ctypes.c_uint8:
         beatmap_bytes = Sliceu8(data=ctypes.cast(beatmap_bytes, ctypes.POINTER(ctypes.c_uint8)), len=len(beatmap_bytes))
 
-    return c_lib.calculate_score_bytes(beatmap_bytes, mode, mods, max_combo, accuracy, count_300, count_100, count_50, miss_count, passed_objects)
+    return c_lib.calculate_performance_from_bytes(beatmap_bytes, mode, mods, max_combo, accuracy, count_300, count_100, count_50, miss_count, passed_objects)
 
 
 

--- a/bindings/akatsuki_pp_ffi.py
+++ b/bindings/akatsuki_pp_ffi.py
@@ -10,14 +10,22 @@ def init_lib(path):
     global c_lib
     c_lib = ctypes.cdll.LoadLibrary(path)
 
-    c_lib.calculate_score.argtypes = [ctypes.POINTER(ctypes.c_int8), ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_double, ctypes.c_uint32, Optionu32]
+    c_lib.calculate_score.argtypes = [ctypes.POINTER(ctypes.c_int8), ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32, Optionf64, Optionu32, Optionu32, Optionu32, ctypes.c_uint32, Optionu32]
+    c_lib.calculate_score_bytes.argtypes = [Sliceu8, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32, Optionf64, Optionu32, Optionu32, Optionu32, ctypes.c_uint32, Optionu32]
 
     c_lib.calculate_score.restype = CalculatePerformanceResult
+    c_lib.calculate_score_bytes.restype = CalculatePerformanceResult
 
 
 
-def calculate_score(beatmap_path: ctypes.POINTER(ctypes.c_int8), mode: int, mods: int, max_combo: int, accuracy: float, miss_count: int, passed_objects: Optionu32) -> CalculatePerformanceResult:
-    return c_lib.calculate_score(beatmap_path, mode, mods, max_combo, accuracy, miss_count, passed_objects)
+def calculate_score(beatmap_path: ctypes.POINTER(ctypes.c_int8), mode: int, mods: int, max_combo: int, accuracy: Optionf64, count_300: Optionu32, count_100: Optionu32, count_50: Optionu32, miss_count: int, passed_objects: Optionu32) -> CalculatePerformanceResult:
+    return c_lib.calculate_score(beatmap_path, mode, mods, max_combo, accuracy, count_300, count_100, count_50, miss_count, passed_objects)
+
+def calculate_score_bytes(beatmap_bytes: Sliceu8 | ctypes.Array[ctypes.c_uint8], mode: int, mods: int, max_combo: int, accuracy: Optionf64, count_300: Optionu32, count_100: Optionu32, count_50: Optionu32, miss_count: int, passed_objects: Optionu32) -> CalculatePerformanceResult:
+    if hasattr(beatmap_bytes, "_length_") and getattr(beatmap_bytes, "_type_", "") == ctypes.c_uint8:
+        beatmap_bytes = Sliceu8(data=ctypes.cast(beatmap_bytes, ctypes.POINTER(ctypes.c_uint8)), len=len(beatmap_bytes))
+
+    return c_lib.calculate_score_bytes(beatmap_bytes, mode, mods, max_combo, accuracy, count_300, count_100, count_50, miss_count, passed_objects)
 
 
 
@@ -66,13 +74,22 @@ class CalculatePerformanceResult(ctypes.Structure):
     _fields_ = [
         ("pp", ctypes.c_double),
         ("stars", ctypes.c_double),
+        ("ar", ctypes.c_double),
+        ("od", ctypes.c_double),
+        ("max_combo", ctypes.c_uint32),
     ]
 
-    def __init__(self, pp: float = None, stars: float = None):
+    def __init__(self, pp: float = None, stars: float = None, ar: float = None, od: float = None, max_combo: int = None):
         if pp is not None:
             self.pp = pp
         if stars is not None:
             self.stars = stars
+        if ar is not None:
+            self.ar = ar
+        if od is not None:
+            self.od = od
+        if max_combo is not None:
+            self.max_combo = max_combo
 
     @property
     def pp(self) -> float:
@@ -89,6 +106,55 @@ class CalculatePerformanceResult(ctypes.Structure):
     @stars.setter
     def stars(self, value: float):
         return ctypes.Structure.__set__(self, "stars", value)
+
+    @property
+    def ar(self) -> float:
+        return ctypes.Structure.__get__(self, "ar")
+
+    @ar.setter
+    def ar(self, value: float):
+        return ctypes.Structure.__set__(self, "ar", value)
+
+    @property
+    def od(self) -> float:
+        return ctypes.Structure.__get__(self, "od")
+
+    @od.setter
+    def od(self, value: float):
+        return ctypes.Structure.__set__(self, "od", value)
+
+    @property
+    def max_combo(self) -> int:
+        return ctypes.Structure.__get__(self, "max_combo")
+
+    @max_combo.setter
+    def max_combo(self, value: int):
+        return ctypes.Structure.__set__(self, "max_combo", value)
+
+
+class Optionf64(ctypes.Structure):
+    """May optionally hold a value."""
+
+    _fields_ = [
+        ("_t", ctypes.c_double),
+        ("_is_some", ctypes.c_uint8),
+    ]
+
+    @property
+    def value(self) -> ctypes.c_double:
+        """Returns the value if it exists, or None."""
+        if self._is_some == 1:
+            return self._t
+        else:
+            return None
+
+    def is_some(self) -> bool:
+        """Returns true if the value exists."""
+        return self._is_some == 1
+
+    def is_none(self) -> bool:
+        """Returns true if the value does not exist."""
+        return self._is_some != 0
 
 
 class Optionu32(ctypes.Structure):
@@ -114,6 +180,63 @@ class Optionu32(ctypes.Structure):
     def is_none(self) -> bool:
         """Returns true if the value does not exist."""
         return self._is_some != 0
+
+
+class Sliceu8(ctypes.Structure):
+    # These fields represent the underlying C data layout
+    _fields_ = [
+        ("data", ctypes.POINTER(ctypes.c_uint8)),
+        ("len", ctypes.c_uint64),
+    ]
+
+    def __len__(self):
+        return self.len
+
+    def __getitem__(self, i) -> int:
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
+
+    def copied(self) -> Sliceu8:
+        """Returns a shallow, owned copy of the underlying slice.
+
+        The returned object owns the immediate data, but not the targets of any contained
+        pointers. In other words, if your struct contains any pointers the returned object
+        may only be used as long as these pointers are valid. If the struct did not contain
+        any pointers the returned object is valid indefinitely."""
+        array = (ctypes.c_uint8 * len(self))()
+        ctypes.memmove(array, self.data, len(self) * ctypes.sizeof(ctypes.c_uint8))
+        rval = Sliceu8(data=ctypes.cast(array, ctypes.POINTER(ctypes.c_uint8)), len=len(self))
+        rval.owned = array  # Store array in returned slice to prevent memory deallocation
+        return rval
+
+    def __iter__(self) -> typing.Iterable[ctypes.c_uint8]:
+        return _Iter(self)
+
+    def iter(self) -> typing.Iterable[ctypes.c_uint8]:
+        """Convenience method returning a value iterator."""
+        return iter(self)
+
+    def first(self) -> int:
+        """Returns the first element of this slice."""
+        return self[0]
+
+    def last(self) -> int:
+        """Returns the last element of this slice."""
+        return self[len(self)-1]
+
+    def bytearray(self):
+        """Returns a bytearray with the content of this slice."""
+        rval = bytearray(len(self))
+        for i in range(len(self)):
+            rval[i] = self[i]
+        return rval
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@ use akatsuki_pp::{
     Beatmap,
 };
 use interoptopus::{
-    extra_type, ffi_function, ffi_type, function, patterns::option::FFIOption, Inventory,
-    InventoryBuilder,
+    extra_type, ffi_function, ffi_type, function,
+    patterns::{option::FFIOption, slice::FFISlice},
+    Inventory, InventoryBuilder,
 };
 use std::ffi::CStr;
 use std::os::raw::c_char;
@@ -17,12 +18,19 @@ use std::os::raw::c_char;
 pub struct CalculatePerformanceResult {
     pub pp: f64,
     pub stars: f64,
+    pub ar: f64,
+    pub od: f64,
+    pub max_combo: u32,
 }
 
 impl std::fmt::Display for CalculatePerformanceResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut s = f.debug_struct("CalculateResult");
-        s.field("pp", &self.pp).field("stars", &self.stars);
+        let mut s = f.debug_struct("CalculatePerformanceResult");
+        s.field("pp", &self.pp)
+            .field("stars", &self.stars)
+            .field("ar", &self.ar)
+            .field("od", &self.od)
+            .field("max_combo", &self.max_combo);
 
         s.finish()
     }
@@ -33,6 +41,15 @@ impl CalculatePerformanceResult {
         Self {
             pp: attributes.pp(),
             stars: attributes.stars(),
+            ar: match attributes {
+                PerformanceAttributes::Osu(ref attrs) => attrs.difficulty.ar,
+                _ => 0.0,
+            },
+            od: match attributes {
+                PerformanceAttributes::Osu(ref attrs) => attrs.difficulty.od,
+                _ => 0.0,
+            },
+            max_combo: attributes.max_combo(),
         }
     }
 
@@ -40,33 +57,42 @@ impl CalculatePerformanceResult {
         Self {
             pp: attributes.pp,
             stars: attributes.difficulty.stars,
+            ar: attributes.difficulty.ar,
+            od: attributes.difficulty.od,
+            max_combo: attributes.difficulty.max_combo as u32,
         }
     }
 }
 
-#[ffi_function]
-#[no_mangle]
-pub unsafe extern "C" fn calculate_score(
-    beatmap_path: *const c_char,
+fn calculate_performance(
+    beatmap: Beatmap,
     mode: u32,
     mods: u32,
     max_combo: u32,
-    accuracy: f64,
+    accuracy: Option<f64>,
+    count_300: Option<u32>,
+    count_100: Option<u32>,
+    count_50: Option<u32>,
     miss_count: u32,
-    passed_objects: FFIOption<u32>,
+    passed_objects: Option<u32>,
 ) -> CalculatePerformanceResult {
-    let beatmap = Beatmap::from_path(CStr::from_ptr(beatmap_path).to_str().unwrap()).unwrap();
-
     // osu!std rx
     if mode == 0 && mods & 128 > 0 {
         let mut calculator = OsuPP::from_map(&beatmap);
         calculator = calculator.mods(mods).combo(max_combo).misses(miss_count);
 
-        if let Some(passed_objects) = passed_objects.into_option() {
+        if let Some(passed_objects) = passed_objects {
             calculator = calculator.passed_objects(passed_objects);
         }
 
-        calculator = calculator.accuracy(accuracy as f32);
+        if let Some(accuracy) = accuracy {
+            calculator = calculator.accuracy(accuracy as f32);
+        } else {
+            calculator = calculator
+                .n300(count_300.unwrap())
+                .n100(count_100.unwrap())
+                .n50(count_50.unwrap());
+        }
 
         let rosu_result = calculator.calculate();
         CalculatePerformanceResult::from_rx_attributes(rosu_result)
@@ -86,20 +112,136 @@ pub unsafe extern "C" fn calculate_score(
             .combo(max_combo)
             .misses(miss_count);
 
-        if let Some(passed_objects) = passed_objects.into_option() {
+        if let Some(passed_objects) = passed_objects {
             calculator = calculator.passed_objects(passed_objects);
         }
 
-        calculator = calculator.accuracy(accuracy);
+        if let Some(accuracy) = accuracy {
+            calculator = calculator.accuracy(accuracy);
+        } else {
+            calculator = calculator
+                .n300(count_300.unwrap())
+                .n100(count_100.unwrap())
+                .n50(count_50.unwrap());
+        }
 
         let rosu_result = calculator.calculate();
         CalculatePerformanceResult::from_attributes(rosu_result)
     }
 }
 
+#[ffi_function]
+#[no_mangle]
+pub unsafe extern "C" fn calculate_score(
+    beatmap_path: *const c_char,
+    mode: u32,
+    mods: u32,
+    max_combo: u32,
+    accuracy: FFIOption<f64>,
+    count_300: FFIOption<u32>,
+    count_100: FFIOption<u32>,
+    count_50: FFIOption<u32>,
+    miss_count: u32,
+    passed_objects: FFIOption<u32>,
+) -> CalculatePerformanceResult {
+    let beatmap = Beatmap::from_path(CStr::from_ptr(beatmap_path).to_str().unwrap()).unwrap();
+
+    calculate_performance(
+        beatmap,
+        mode,
+        mods,
+        max_combo,
+        accuracy.into_option(),
+        count_300.into_option(),
+        count_100.into_option(),
+        count_50.into_option(),
+        miss_count,
+        passed_objects.into_option(),
+    )
+}
+
+#[ffi_function]
+#[no_mangle]
+pub unsafe extern "C" fn calculate_score_bytes(
+    beatmap_bytes: FFISlice<u8>,
+    mode: u32,
+    mods: u32,
+    max_combo: u32,
+    accuracy: FFIOption<f64>,
+    count_300: FFIOption<u32>,
+    count_100: FFIOption<u32>,
+    count_50: FFIOption<u32>,
+    miss_count: u32,
+    passed_objects: FFIOption<u32>,
+) -> CalculatePerformanceResult {
+    let beatmap = Beatmap::from_bytes(beatmap_bytes.as_slice()).unwrap();
+
+    calculate_performance(
+        beatmap,
+        mode,
+        mods,
+        max_combo,
+        accuracy.into_option(),
+        count_300.into_option(),
+        count_100.into_option(),
+        count_50.into_option(),
+        miss_count,
+        passed_objects.into_option(),
+    )
+}
+
 pub fn my_inventory() -> Inventory {
     InventoryBuilder::new()
         .register(extra_type!(CalculatePerformanceResult))
         .register(function!(calculate_score))
+        .register(function!(calculate_score_bytes))
         .inventory()
+}
+
+#[test]
+fn generate_csharp_bindings() {
+    use interoptopus::Interop;
+    use interoptopus_backend_csharp::{Config, Generator};
+
+    let inventory = my_inventory();
+
+    let config = Config {
+        dll_name: "akatsuki_pp".to_string(),
+        ..Config::default()
+    };
+
+    Generator::new(config, inventory)
+        .write_file("bindings/AkatsukiPPFFI.cs")
+        .unwrap();
+}
+
+#[test]
+fn generate_c_bindings() {
+    use interoptopus::Interop;
+    use interoptopus_backend_c::{Config, Generator};
+
+    let inventory = my_inventory();
+
+    let config = Config {
+        ifndef: "akatsuki_pp".to_string(),
+        ..Config::default()
+    };
+
+    Generator::new(config, inventory)
+        .write_file("bindings/akatsuki_pp_ffi.h")
+        .unwrap();
+}
+
+#[test]
+fn generate_cpython_bindings() {
+    use interoptopus::Interop;
+    use interoptopus_backend_cpython::{Config, Generator};
+
+    let inventory = my_inventory();
+
+    let config = Config::default();
+
+    Generator::new(config, inventory)
+        .write_file("bindings/akatsuki_pp_ffi.py")
+        .unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ fn calculate_performance(
 
 #[ffi_function]
 #[no_mangle]
-pub unsafe extern "C" fn calculate_score(
+pub unsafe extern "C" fn calculate_performance_from_path(
     beatmap_path: *const c_char,
     mode: u32,
     mods: u32,
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn calculate_score(
 
 #[ffi_function]
 #[no_mangle]
-pub unsafe extern "C" fn calculate_score_bytes(
+pub unsafe extern "C" fn calculate_performance_from_bytes(
     beatmap_bytes: FFISlice<u8>,
     mode: u32,
     mods: u32,
@@ -193,8 +193,8 @@ pub unsafe extern "C" fn calculate_score_bytes(
 pub fn my_inventory() -> Inventory {
     InventoryBuilder::new()
         .register(extra_type!(CalculatePerformanceResult))
-        .register(function!(calculate_score))
-        .register(function!(calculate_score_bytes))
+        .register(function!(calculate_performance_from_path))
+        .register(function!(calculate_performance_from_bytes))
         .inventory()
 }
 


### PR DESCRIPTION
Expands FFI interface with intent of being used in a C# rewrite of performance-service.

- Adds export to calculate pp with byte data directly instead of a file path for a beatmap
- Attach AR & OD to output for osu!std
- Attach max combo to output
- Add back tests for interoptopus binding generation
- Make accuracy optional param in favour of adding optional hit statistics params - allow either or to be passed

These are already going to result in breaking changes to the API so I may decide to do some further renames/restructures of the interface before merging.